### PR TITLE
Skip tags that are mapped to empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,19 @@ See [app.json](https://github.com/somleng/dockerhub2ci/blob/master/app.json) for
 
 Optional configuration options are listed below:
 
+### `DISABLE_TAG_PASSTHROUGH`
+
+By default all Dockerhub tags will be used to trigger builds using the same branch name, unless name remapping is defined with `TAG_MAPPINGS`. Should you want to only rely on `TAG_MAPPINGS` and prevent any unknown Dockerhub tags from triggering build, set this to `1`.
+
+Defaults to `0`
+
 ### `REPO_MAPPINGS`
 
 One or more Dockerhub repo to build repo name mappings (separated by semicolons (;)). For example if you want the Dockerhub repository `somleng-docker/dockerhub2ci` to trigger a build on `somleng/dockerhub2ci` set `REPO_MAPPINGS=somleng-docker/dockerhub2ci=somleng/dockerhub2ci`. If there is no mapping for the Dockerhub repo, it's assumed the build repo is the same as the Dockerhub repo.
 
 ### `TAG_MAPPINGS`
 
-One or more Dockerhub tag to build branch name mappings (separated by semicolons (;)). For example if you want the `lastest` Dockerhub tag to trigger a build on the `staging` branch and the `stable` Dockerhub tag to trigger a build on the master branch set `TAG_MAPPINGS=latest=staging;stable=master`. If there is no mapping for the Dockerhub tag, it's assumed the build branch name is the same as the Dockerhub tag name.
+One or more Dockerhub tag to build branch name mappings (separated by semicolons (;)). For example if you want the `lastest` Dockerhub tag to trigger a build on the `staging` branch and the `stable` Dockerhub tag to trigger a build on the master branch set `TAG_MAPPINGS=latest=staging;stable=master`. If there is no mapping for the Dockerhub tag, it's assumed the build branch name is the same as the Dockerhub tag name. However if a mapping for the Dockerhub tag does exist but is empty, then it will be skipped: no builds for this tag will be triggered. 
 
 Defaults to `latest=master`
 

--- a/app/models/webhook_subscriber/base.rb
+++ b/app/models/webhook_subscriber/base.rb
@@ -1,5 +1,5 @@
 class WebhookSubscriber::Base
-  delegate :tag_mappings, :repo_mappings, :to => :class
+  delegate :tag_mappings, :tag_passthrough?, :repo_mappings, :to => :class
 
   DEFAULT_TAG_MAPPINGS = {
     "latest" => "master"
@@ -15,12 +15,20 @@ class WebhookSubscriber::Base
     DEFAULT_TAG_MAPPINGS.merge(env_tag_mappings)
   end
 
+  def self.tag_passthrough?
+    env_tag_passthrough?
+  end
+
   def self.repo_mappings
     env_repo_mappings
   end
 
   def self.env_tag_mappings
     parse_key_value_pairs(ENV["TAG_MAPPINGS"])
+  end
+
+  def self.env_tag_passthrough?
+    ENV["DISABLE_TAG_PASSTHROUGH"].to_i.zero?
   end
 
   def self.env_repo_mappings

--- a/spec/models/webhook_subscriber/travis_spec.rb
+++ b/spec/models/webhook_subscriber/travis_spec.rb
@@ -98,6 +98,46 @@ describe WebhookSubscriber::Travis do
       it { assert_perform! }
     end
 
+    context "with tag mapping to empty branch name" do
+      let(:tag) { "some_tag" }
+      let(:branch_name) { "" }
+
+      def env
+        super.merge(:tag_mappings => "#{tag}=#{branch_name}")
+      end
+
+      def assert_response!
+        expect(request).to be_nil
+      end
+
+      it { assert_response! }
+    end
+
+    context "with tag passthrough disabled" do
+      let(:tag) { "some_tag" }
+
+      def env
+        super.merge(:disable_tag_passthrough => "1")
+      end
+
+      def assert_response!
+        expect(request).to be_nil
+      end
+
+      it { assert_response! }
+    end
+
+    context "with tag passthrough enabled" do
+      let(:tag) { "some_tag" }
+      let(:asserted_build_branch_name) { tag }
+
+      def env
+        super.merge(:disable_tag_passthrough => "0")
+      end
+
+      it { assert_perform! }
+    end
+
     context "with repo_mappings" do
       let(:asserted_build_repo_user) { "another-user" }
       let(:asserted_build_repo_name) { "some-gh-repo" }


### PR DESCRIPTION
Currently, all webhook requests from Docker Hub are being transformed into CI requests. However, it would be useful to drop some requests for tags that should not be processed, for instance when trying to prevent circular build loops between Travis CI and Docker Hub. One could use TAG_MAPPINGS to map them to non-existant git branches, but this still sends a CI request ...and Travis CI has a pretty low rate limit to start with.

This proposed solution allows for empty values in TAG_MAPPINGS that would then get skipped. Say, when using `TAG_MAPPINGS="prod=master;test=master;develop="` then only a webhook call containing `prod` or `test` would trigger a build request for the `master` branch while the `develop` webhook call would be skipped.

Do feel free to edit this PR for style and function, as I am less familiar with Ruby. 😃
